### PR TITLE
Add workflow to build & deploy to gh-pages on local repo

### DIFF
--- a/.github/workflows/push-publish-local.yml
+++ b/.github/workflows/push-publish-local.yml
@@ -1,0 +1,40 @@
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+name: push-build&deploy-localRepo
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Push to local - Build and deploy docs to Github Pages on local repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Install Antora
+        run: npm install
+
+      - name: Generate Site
+        run: npx antora --fetch antora-playbook.yml
+
+      - name: Unzip archive
+        run: unzip build/site.zip -d build/site
+
+      - name: Remove archive
+        run: rm build/site.zip
+
+      - name: Deploy to local repo Github Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: build/site

--- a/.github/workflows/release-publish-remote.yml
+++ b/.github/workflows/release-publish-remote.yml
@@ -4,11 +4,11 @@ on:
       - published
   workflow_dispatch:
 
-name: build-and-push-githubpages
+name: release-build&push-mainRepo
 
 jobs:
   build:
-    name: Build and push docs to Github Pages
+    name: Release - Build and push docs to Github Pages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Added a workflow that will build the docs on push to main and deploy the resulting folder to the gh-pages branch on this repo.
Also renamed the release workflow 